### PR TITLE
Interaction components are not required

### DIFF
--- a/1.0.1/interactionactivity_choices.json
+++ b/1.0.1/interactionactivity_choices.json
@@ -3,7 +3,7 @@
     "id": "#interactionactivity_choices",
     "type": "object",
     "allOf": [{"$ref": "#interactionactivity_base"}],
-    "required": ["choices", "interactionType"],
+    "required": ["interactionType"],
     "properties": {
         "choices": {"$ref": "#interactioncomponent_list"},
         "scale": {"type": "null"},

--- a/1.0.1/interactionactivity_scale.json
+++ b/1.0.1/interactionactivity_scale.json
@@ -3,7 +3,7 @@
     "id": "#interactionactivity_scale",
     "type": "object",
     "allOf": [{"$ref": "#interactionactivity_base"}],
-    "required": ["scale", "interactionType"],
+    "required": ["interactionType"],
     "properties": {
         "choices": {"type": "null"},
         "scale": {"$ref": "#interactioncomponent_list"},

--- a/1.0.1/interactionactivity_sourcetarget.json
+++ b/1.0.1/interactionactivity_sourcetarget.json
@@ -3,7 +3,7 @@
     "id": "#interactionactivity_sourcetarget",
     "type": "object",
     "allOf": [{"$ref": "#interactionactivity_base"}],
-    "required": ["source", "target", "interactionType"],
+    "required": ["interactionType"],
     "properties": {
         "choices": {"type": "null"},
         "scale": {"type": "null"},

--- a/1.0.1/interactionactivity_steps.json
+++ b/1.0.1/interactionactivity_steps.json
@@ -3,7 +3,7 @@
     "id": "#interactionactivity_steps",
     "type": "object",
     "allOf": [{"$ref": "#interactionactivity_base"}],
-    "required": ["steps", "interactionType"],
+    "required": ["interactionType"],
     "properties": {
         "choices": {"type": "null"},
         "scale": {"type": "null"},

--- a/1.0.1/interactioncomponent_list.json
+++ b/1.0.1/interactioncomponent_list.json
@@ -3,5 +3,5 @@
     "id": "#interactioncomponent_list",
     "type": "array",
     "items": {"$ref": "#interactioncomponent"},
-    "minItems": 1
+    "minItems": 0
 }


### PR DESCRIPTION
The xAPI spec desribes interaction components that can be included
for each interaction type, but does not mandate that they are included,
or if they are included that they are not an empty list.

Adjust schema so they are optional, and lists may be empty.